### PR TITLE
Set Paul as code owner for branch protections

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@dipanjyoti/main
+@dipanjyoti


### PR DESCRIPTION
Per docs: A CODEOWNERS file uses a pattern that follows most of the same rules used in gitignore files. The pattern is followed by one or more GitHub usernames or team names using the standard @username or @org/team-name format.

The branch protection rule is set to apply to the `main` branch through the settings rather than this file.